### PR TITLE
[simulator] Always use bash to run simulation scripts

### DIFF
--- a/simulator/run_all_simulations.sh
+++ b/simulator/run_all_simulations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is part of the Soletta Project
 #

--- a/simulator/run_massif_simulations.sh
+++ b/simulator/run_massif_simulations.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is part of the Soletta Project
 #


### PR DESCRIPTION
In some systems sh is linked to dash or any other sh. The scripts are
using bash syntax, so we need to force them to use bash

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
