### PR TITLE
[soletta_module] Set default rgb parameter correctly in gtk conf file

### DIFF
--- a/soletta_module/samples/foosball/gtk_fuzzy.json
+++ b/soletta_module/samples/foosball/gtk_fuzzy.json
@@ -20,14 +20,22 @@
   {
    "name": "Led1",
    "options": {
-    "rgb": "255|0|0"
+    "rgb": {
+     "red": 255,
+     "green": 0,
+     "blue": 0
+    }
    },
    "type": "gtk/led"
   },
   {
    "name": "Led2",
    "options": {
-    "rgb": "255|255|0"
+    "rgb": {
+     "red": 255,
+     "green": 255,
+     "blue": 0
+    }
    },
    "type": "gtk/led"
   },


### PR DESCRIPTION
Soletta gtk/led has changed and rgb option is no longer a string. Now it
is a regular rgb field

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
