### PR TITLE
soletta_module: Add debug port to sml sync nodes

### DIFF
--- a/soletta_module/machine_learning/machine_learning.json
+++ b/soletta_module/machine_learning/machine_learning.json
@@ -308,6 +308,14 @@
          "process": "sml_data_process"
         },
         "name": "IN_PREDICT"
+       },
+       {
+        "data_type": "string",
+        "description": "File to log sml read data and predicted outputs.",
+        "methods": {
+         "process": "sml_data_debug_file"
+        },
+        "name": "DEBUG_FILE"
        }
       ],
       "methods": {
@@ -361,6 +369,14 @@
          "process": "sml_data_process"
         },
         "name": "IN_PREDICT"
+       },
+       {
+        "data_type": "string",
+        "description": "File to log sml read data and predicted outputs.",
+        "methods": {
+         "process": "sml_data_debug_file"
+        },
+        "name": "DEBUG_FILE"
        }
       ],
       "methods": {


### PR DESCRIPTION
Make it possible for users to log sml read and predicted values for
debug purposes.
File name received in port DEBUG_FILE will be used for logging. If file
name is empty, no log will be stored.

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
