### PR TITLE
soletta_module: Add debug port to sml sync nodes

### DIFF
--- a/soletta_module/machine_learning/machine_learning.c
+++ b/soletta_module/machine_learning/machine_learning.c
@@ -1131,10 +1131,13 @@ struct machine_learning_sync_data {
     //Used only in open method or/and worker thread. No need to lock
     struct sml_object *sml;
     uint16_t number_of_terms;
-    struct sol_flow_node *node;
     struct sml_data_priv *cur_sml_data;
     double *output_steps;
     uint16_t output_steps_len;
+
+    //Used only in main thread. No need to lock
+    struct sol_flow_node *node;
+    FILE *debug_file;
 
     //Used by main thread and process thread. Need to be locked
     struct sol_ptr_vector input_queue;
@@ -1223,6 +1226,50 @@ machine_learning_sync_update_variables(struct machine_learning_sync_data *mdata,
 #undef VARIABLE_INPUT_PREFIX
 #undef VARIABLE_OUTPUT_PREFIX
 
+static void
+sync_debug_log_list(FILE *debug_file, struct sol_drange *array,
+    uint16_t array_len)
+{
+    uint16_t i;
+
+    for (i = 0; i < array_len; i++) {
+        fprintf(debug_file, " %f %f %f %f", array[i].val, array[i].min,
+            array[i].max, array[i].step);
+        if (i < array_len - 1)
+            fprintf(debug_file, ";");
+    }
+}
+
+static void
+sync_debug_log_sml_data(FILE *debug_file,
+    struct packet_type_sml_data_packet_data *sml_data, bool predict)
+{
+    if (!debug_file)
+        return;
+
+    if (predict)
+        fprintf(debug_file, "PREDICT INPUTS");
+    else
+        fprintf(debug_file, "PROCESS INPUTS");
+    sync_debug_log_list(debug_file, sml_data->inputs, sml_data->inputs_len);
+    fprintf(debug_file, " OUTPUTS");
+    sync_debug_log_list(debug_file, sml_data->outputs, sml_data->outputs_len);
+    fprintf(debug_file, "\n");
+}
+
+static void
+sync_debug_log_sml_output_data(FILE *debug_file,
+    struct packet_type_sml_output_data_packet_data *sml_output_data)
+{
+    if (!debug_file)
+        return;
+
+    fprintf(debug_file, "OUTPUT_STATE_CHANGED_CB ");
+    sync_debug_log_list(debug_file, sml_output_data->outputs,
+        sml_output_data->outputs_len);
+    fprintf(debug_file, "\n");
+}
+
 static int
 machine_learning_sync_pre_process(struct machine_learning_sync_data *mdata)
 {
@@ -1307,6 +1354,8 @@ machine_learning_sync_worker_thread_feedback(void *data)
         r = sml_output_data_send_packet(mdata->node,
             SOL_FLOW_NODE_TYPE_MACHINE_LEARNING_FUZZY_SYNC__OUT__OUT,
             sml_output_data);
+        sync_debug_log_sml_output_data(mdata->debug_file,
+            sml_output_data);
         packet_type_sml_output_data_packet_dispose(NULL, sml_output_data);
         free(sml_output_data);
     }
@@ -1354,6 +1403,8 @@ machine_learning_sync_close(struct sol_flow_node *node, void *data)
 {
     struct machine_learning_sync_data *mdata = data;
 
+    if (mdata->debug_file)
+        fclose(mdata->debug_file);
     sml_free(mdata->sml);
 }
 
@@ -1406,6 +1457,9 @@ sml_data_process(struct sol_flow_node *node, void *data, uint16_t port,
 
     pthread_mutex_unlock(&mdata->queue_lock);
 
+    sync_debug_log_sml_data(mdata->debug_file, &sml_data,
+        new_sml_data->predict);
+
     if (!mdata->worker)
         return machine_learning_sync_worker_schedule(mdata);
     return 0;
@@ -1443,9 +1497,12 @@ sync_read_state_cb(struct sml_object *sml, void *data)
         mdata->cur_sml_data->base.inputs, mdata->cur_sml_data->base.inputs_len))
         return false;
 
-    return sync_fill_variables(sml, sml_get_output_list(sml),
+    if (!sync_fill_variables(sml, sml_get_output_list(sml),
         mdata->cur_sml_data->base.outputs,
-        mdata->cur_sml_data->base.outputs_len);
+        mdata->cur_sml_data->base.outputs_len))
+        return false;
+
+    return true;
 }
 
 static void
@@ -1591,6 +1648,36 @@ neural_network_sync_open(struct sol_flow_node *node, void *data,
 err:
     sml_free(mdata->sml);
     return r;
+}
+
+static int
+sml_data_debug_file(struct sol_flow_node *node, void *data, uint16_t port,
+    uint16_t conn_id, const struct sol_flow_packet *packet)
+{
+    int r;
+    struct machine_learning_sync_data *mdata = data;
+    const char *str;
+
+    r = sol_flow_packet_get_string(packet, &str);
+    SOL_INT_CHECK(r, < 0, r);
+    SOL_NULL_CHECK(str, -EINVAL);
+
+    if (mdata->debug_file)
+        fclose(mdata->debug_file);
+
+    if (str[0] == 0) {
+        mdata->debug_file = NULL;
+        return 0;
+    }
+
+    mdata->debug_file = fopen(str, "a");
+    SOL_NULL_CHECK(mdata->debug_file, -ENOMEM);
+    fprintf(mdata->debug_file, "#PROCESS INPUTS val min max step;"
+        " val min max step; val min max step;... OUTPUTS val min max step;"
+        " val min max step; val min max step;...\n");
+    fprintf(mdata->debug_file, "#OUTPUT_STATE_CHANGED_CB val min max step;"
+            " val min max step; val min max step;...\n");
+    return 0;
 }
 
 static int

--- a/soletta_module/machine_learning/machine_learning.json
+++ b/soletta_module/machine_learning/machine_learning.json
@@ -308,6 +308,14 @@
          "process": "sml_data_process"
         },
         "name": "IN_PREDICT"
+       },
+       {
+        "data_type": "string",
+        "description": "File to log sml read data and predicted outputs.",
+        "methods": {
+         "process": "sml_data_debug_file"
+        },
+        "name": "DEBUG_FILE"
        }
       ],
       "methods": {
@@ -361,6 +369,14 @@
          "process": "sml_data_process"
         },
         "name": "IN_PREDICT"
+       },
+       {
+        "data_type": "string",
+        "description": "File to log sml read data and predicted outputs.",
+        "methods": {
+         "process": "sml_data_debug_file"
+        },
+        "name": "DEBUG_FILE"
        }
       ],
       "methods": {


### PR DESCRIPTION
Make it possible for users to log sml read and predicted values for
debug purposes.
File name received in port DEBUG_FILE will be used for logging. If file
name is empty, no log will be stored.

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
