### PR TITLE
Sml Garden: Add an safety measures for engine_controller.fbp

### DIFF
--- a/soletta_module/samples/sml_garden/engine_controller.fbp
+++ b/soletta_module/samples/sml_garden/engine_controller.fbp
@@ -31,13 +31,15 @@
 # This module is responsible for leaving the engine on for X seconds,
 # where X is an input.
 
-INPORT=ConverterSeconds.IN:SECONDS
+INPORT=ClassifyFloat.IN:SECONDS
 OUTPORT=IsEngineOn.OUT:OUT
 
-MilliSeconds(constant/int:value=1000) OUT -> OPERAND[0] ToMilliSeconds(int/multiplication)
-ConverterSeconds(converter/float-to-int) OUT -> OPERAND[1] ToMilliSeconds OUT -> INTERVAL Timer(timer:interval=0)
+ClassifyFloat(float/classify) NORMAL -> IN _(converter/float-to-int) OUT -> IN Filter(int/filter:min=0, max=60)
 
-ConverterSeconds OUT -> IN ConverterRange(converter/int-to-boolean:true_range=min:1|max:INT32_MAX) OUT -> ENABLED Timer
+MilliSeconds(constant/int:value=1000) OUT -> OPERAND[0] ToMilliSeconds(int/multiplication)
+Filter OUT -> OPERAND[1] ToMilliSeconds OUT -> INTERVAL Timer(timer:interval=0)
+
+Filter OUT -> IN ConverterRange(converter/int-to-boolean:true_range=min:1|max:INT32_MAX) OUT -> ENABLED Timer
 
 Timer OUT -> IN ConverterEmpty(converter/empty-to-boolean:output_value=false) OUT -> ENABLED Timer
 


### PR DESCRIPTION
The engine controller should ignore float values that are not normal,
or values that are too big. This is usefull, because in some cases
the ANN/Fuzzy engine may not have good predictions (lack of data,
the user does not follow a pattern, etc.).

Signed-off-by: Guilherme Iscaro guilherme.iscaro@intel.com
