### PR TITLE
soletta_module: Make it possible to set is_id when using sml-sync nodes

### DIFF
--- a/soletta_module/machine_learning/machine_learning_sml_data.h
+++ b/soletta_module/machine_learning/machine_learning_sml_data.h
@@ -9,9 +9,10 @@ extern "C" {
 #endif
 
 struct packet_type_sml_data_packet_data {
-    uint16_t inputs_len, outputs_len;
+    uint16_t inputs_len, outputs_len, output_ids_len, input_ids_len;
     struct sol_drange *inputs;
     struct sol_drange *outputs;
+    bool *output_ids, *input_ids;
 };
 
 struct packet_type_sml_output_data_packet_data {


### PR DESCRIPTION
Add optional parameter in custom data used by sml-sync node to set which
variables are id fields.

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
