### PR TITLE
fuzzy: Fix warnings reported when building with Release mode

### DIFF
--- a/sml/sml_fuzzy/src/sml_fuzzy.c
+++ b/sml/sml_fuzzy/src/sml_fuzzy.c
@@ -425,8 +425,10 @@ _act(struct sml_fuzzy_engine *fuzzy_engine, bool *should_learn)
     struct sml_matrix output_membership;
     struct sol_vector changed_idx = SOL_VECTOR_INIT(uint16_t);
     struct sml_variables_list *changed;
-    struct sml_variable *variable;
     int error;
+#ifdef Debug
+    struct sml_variable *variable;
+#endif
 
     //predict outputs
     if ((error = sml_fuzzy_process_output(fuzzy_engine->fuzzy)))
@@ -998,7 +1000,9 @@ _rearrange_fuzzy_terms(struct sml_engine *engine,
     is_id = sml_fuzzy_bridge_variable_get_is_id(fuzzy, variable);
     overlap = width * DEFAULT_OVERLAP_PERCENTAGE;
     first_min = max;
+    first_max = max;
     last_max = min;
+    last_min = min;
     num_terms = sml_fuzzy_variable_terms_count(variable);
     for (i = 0; i < num_terms; i++) {
         term = sml_fuzzy_variable_get_term(variable, i);

--- a/soletta_module/machine_learning/machine_learning.c
+++ b/soletta_module/machine_learning/machine_learning.c
@@ -1193,7 +1193,7 @@ machine_learning_sync_update_variables(struct machine_learning_sync_data *mdata,
 {
     char var_name[SML_VARIABLE_NAME_MAX_LEN + 1];
     float max, min, width;
-    struct sml_variable *var;
+    struct sml_variable *var = NULL;
     struct sol_drange *val;
     uint16_t i, len, array_len, array_ids_len;
     struct sml_variables_list *list;
@@ -1257,7 +1257,7 @@ machine_learning_sync_update_variables(struct machine_learning_sync_data *mdata,
             mdata->output_steps[i] = val->step;
     }
 
-    if (array_ids)
+    if (var && array_ids)
         for (i = 0; i < array_ids_len; i++)
             if (!sml_fuzzy_variable_set_is_id(mdata->sml, var, array_ids[i]))
                 return -EINVAL;


### PR DESCRIPTION
- sml_variable is only used in Debug mode
- some variables may be unitialized

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
