### PR TITLE
sml_garden: Only send a single packet per timeblock to OUT port

### DIFF
--- a/soletta_module/samples/sml_garden/flower_power_status.fbp
+++ b/soletta_module/samples/sml_garden/flower_power_status.fbp
@@ -28,12 +28,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-INPORT=ConverterError.IN:ERROR
+INPORT=ErrorToBoolean.IN:ERROR
 INPORT=FlowerPowerPacket.IN:PACKET
 OUTPORT=LedOutput.OUT[0]:LED_STATUS
 
-Console(console)
-ConverterError(converter/error) CODE -> IN ErrorToBoolean(converter/int-to-boolean)
+ErrorToBoolean(converter/empty-to-boolean:output_value=false)
 FlowerPowerPacket(flower-power/get-value) WATER -> IN FloatToBoolean(converter/float-to-boolean:true_range=min:-1000|max:10000)
 
 

--- a/soletta_module/samples/sml_garden/gtk_sml_garden.json
+++ b/soletta_module/samples/sml_garden/gtk_sml_garden.json
@@ -10,15 +10,15 @@
    "type": "gtk/pushbutton"
   },
   {
-   "name": "EngineFuzzy"
+   "name": "EngineFuzzy",
    "type": "gtk/led"
   },
   {
-   "name": "EngineAnn"
+   "name": "EngineAnn",
    "type": "gtk/led"
   },
   {
-   "name": "FlowerPowerStatusLed"
+   "name": "FlowerPowerStatusLed",
    "type": "gtk/led"
   },
   {

--- a/soletta_module/samples/sml_garden/sml_garden.fbp
+++ b/soletta_module/samples/sml_garden/sml_garden.fbp
@@ -62,7 +62,7 @@ Password OUT -> PASSWORD FlowerPowerAPI
 
 FlowerPowerAPI ERROR -> ERROR FlowerPowerStatus(FlowerPowerStatus)
 FlowerPowerAPI OUT -> PACKET FlowerPowerStatus
-FlowerPowerStatus LED_STATUS -> IN _(FlowerPowerStatusLed)
+FlowerPowerStatus LED_STATUS -> IN Status(FlowerPowerStatusLed)
 
 BtnFuzzy OUT -> IN _(boolean/filter) TRUE -> GET FlowerPowerAPI
 BtnAnn OUT -> IN _(boolean/filter) TRUE -> GET FlowerPowerAPI

--- a/soletta_module/sml_garden/sml_garden.json
+++ b/soletta_module/sml_garden/sml_garden.json
@@ -36,6 +36,9 @@
                     }
                 }
             ],
+            "methods": {
+                "open": "message_constructor_open"
+            },
             "name": "sml-garden/message-constructor",
             "out_ports": [
                 {


### PR DESCRIPTION
Instead of sending packets every time we have a button pressed or a
timeblock changed, only send this information once, at the end of the
timeblock, i.e. count total button pressed time during the timeblock and
send it at the end.
