### PR TITLE
Sml: Fix mkdir race condition.

### DIFF
--- a/sml/common/src/sml_util.c
+++ b/sml/common/src/sml_util.c
@@ -62,10 +62,7 @@ bool
 create_dir(const char *path)
 {
     size_t i, last_i, bytes;
-    int r;
-    struct stat stat_result;
     char aux[PATH_MAX];
-    bool ok = true;
 
     if (strlen(path) + 1 > PATH_MAX) {
         sml_critical("Could not create dir. The path is bigger than PATH_MAX!");
@@ -77,19 +74,11 @@ create_dir(const char *path)
             bytes = i - last_i;
             memcpy(aux + last_i, path + last_i, path[i + 1] == '\0' ? bytes + 1 : bytes);
             last_i = i;
-            r = stat(aux, &stat_result);
-            if (r && errno == ENOENT && mkdir(aux, S_IRWXU | S_IRWXG | S_IROTH)) {
-                ok = false;
-                sml_critical("Could not create the path:%s", aux);
-                break;
-            } else if (!r && !S_ISDIR(stat_result.st_mode)) {
-                ok = false;
-                sml_critical("%s is not a directory", aux);
-                break;
-            }
+            /* Ignore the errors, if everything is ok is_dir() will succeed */
+            (void)mkdir(aux, S_IRWXU | S_IRWXG | S_IROTH);
         }
     }
-    return ok;
+    return is_dir(path);
 }
 
 bool


### PR DESCRIPTION
A race condition may happen during the directory creation,
because the directory can be created by an external process
after stat() is called. Since Sml does not care who created the dir,
ignore the stat call and try to create the directory. If everything
is ok is_dir() will return true.

Signed-off-by: Guilherme Iscaro guilherme.iscaro@intel.com
