### PR TITLE
pr with commits related to: Create infra to save and load debug data

### DIFF
--- a/sml/common/include/sml_engine.h
+++ b/sml/common/include/sml_engine.h
@@ -65,6 +65,9 @@ typedef bool (*sml_engine_variable_set_range)(struct sml_engine *engine, struct 
 typedef bool (*sml_engine_variable_get_range)(struct sml_variable *sml_variable, float *min, float *max);
 typedef void (*sml_engine_print_debug)(struct sml_engine *engine, bool full);
 
+int sml_call_read_state_cb(struct sml_engine *engine);
+void sml_call_output_state_changed_cb(struct sml_engine *engine, struct sml_variables_list *changed);
+
 struct sml_engine {
     /* General API */
     sml_engine_load_file load_file;

--- a/sml/common/include/sml_engine.h
+++ b/sml/common/include/sml_engine.h
@@ -36,6 +36,8 @@
 #include <sml_ann.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <config.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,6 +99,9 @@ struct sml_engine {
 
     /* Debug API */
     sml_engine_print_debug print_debug;
+#ifdef Debug
+    FILE *debug_file;
+#endif
 
     uint32_t magic_number;
     sml_read_state_cb read_state_cb;

--- a/sml/common/src/sml_engine.c
+++ b/sml/common/src/sml_engine.c
@@ -40,8 +40,37 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <config.h>
+#include <stdarg.h>
 
 #define LINE_SIZE (256)
+#define STR_FORMAT(WIDTH) "%" #WIDTH "s"
+#define STR_FMT(W) STR_FORMAT(W)
+
+#ifdef Debug
+#define SML_LOG_DEBUG_DATA(engine, ...)                     \
+    do {                                                    \
+        if (engine->debug_file)                             \
+            fprintf(engine->debug_file, __VA_ARGS__);       \
+    } while (0)
+
+#define SML_LOG_DEBUG_DATA_VAR(engine, prefix, fmt, var, ...)                 \
+    do {                                                                      \
+        if (engine->debug_file)                                               \
+            sml_log_debug_data_var(engine, prefix, fmt, var, ## __VA_ARGS__); \
+    } while (0)
+
+#define SML_LOG_DEBUG_DATA_LIST(engine, prefix, list, ...)                   \
+    do {                                                                     \
+        if (engine->debug_file)                                              \
+            sml_log_debug_data_list(engine, prefix, list, ## __VA_ARGS__);   \
+    } while (0)
+
+#else
+#define SML_LOG_DEBUG_DATA(...)
+#define SML_LOG_DEBUG_DATA_VAR(...)
+#define SML_LOG_DEBUG_DATA_LIST(...)
+#endif
 
 static bool
 _default_load_fll_file(struct sml_object *engine, const char *filename)
@@ -93,6 +122,45 @@ _default_load_fll_file(struct sml_object *engine, const char *filename)
     return true;
 }
 
+#ifdef Debug
+void
+sml_log_debug_data_var(struct sml_engine *engine, const char *prefix,
+    const char *fmt, struct sml_variable *var, ...)
+{
+    int r;
+    va_list args;
+    char name[SML_VARIABLE_NAME_MAX_LEN + 1];
+
+    va_start(args, var);
+    r = sml_variable_get_name((struct sml_object *)engine, var, name,
+        sizeof(name));
+    if (r == 0) {
+        fprintf(engine->debug_file, "%s %s ", prefix, name);
+        vfprintf(engine->debug_file, fmt, args);
+    }
+    va_end(args);
+}
+
+void
+sml_log_debug_data_list(struct sml_engine *engine, const char *prefix,
+    struct sml_variables_list *list)
+{
+    int r;
+    uint16_t len, i;
+    struct sml_variable *var;
+    char name[SML_VARIABLE_NAME_MAX_LEN + 1];
+
+    SML_VARIABLES_LIST_FOREACH((struct sml_object *)engine, list, len, var, i) {
+        r = sml_variable_get_name((struct sml_object *)engine, var, name,
+            sizeof(name));
+        if (r == 0)
+            fprintf(engine->debug_file, "%s %s %f\n", prefix, name,
+                sml_variable_get_value((struct sml_object *)engine, var));
+    }
+
+}
+#endif
+
 API_EXPORT bool
 sml_load_fll_file(struct sml_object *sml, const char *filename)
 {
@@ -115,6 +183,10 @@ sml_free(struct sml_object *sml)
             "sml_free is mandatory for engines.");
         return;
     }
+#ifdef Debug
+    if (engine->debug_file)
+        fclose(engine->debug_file);
+#endif
     engine->free(engine);
 }
 
@@ -153,11 +225,143 @@ sml_set_stabilization_hits(struct sml_object *sml, uint16_t hits)
 }
 
 API_EXPORT bool
+sml_set_debug_data_log_file(struct sml_object *sml, const char *str)
+{
+#ifdef Debug
+    ON_NULL_RETURN_VAL(sml, false);
+    struct sml_engine *engine = (struct sml_engine *)sml;
+
+    if (engine->debug_file)
+        fclose(engine->debug_file);
+
+    if (!str || str[0] == 0) {
+        engine->debug_file = NULL;
+        return true;
+    }
+
+    engine->debug_file = fopen(str, "a");
+    return engine->debug_file != NULL;
+#else
+    return false;
+#endif
+}
+
+#ifdef Debug
+struct sml_variable *
+variable_find_by_name(struct sml_object *sml, const char *name)
+{
+    int r;
+    uint16_t i, len;
+    struct sml_variables_list *list;
+    struct sml_variable *var;
+    char tmp_name[SML_VARIABLE_NAME_MAX_LEN + 1];
+
+    list = sml_get_input_list(sml);
+    SML_VARIABLES_LIST_FOREACH(sml, list, len, var, i) {
+        r = sml_variable_get_name(sml, var, tmp_name, sizeof(tmp_name));
+        if (r == 0 && strncmp(tmp_name, name, sizeof(tmp_name)) == 0)
+            return var;
+    }
+
+    list = sml_get_output_list(sml);
+    SML_VARIABLES_LIST_FOREACH(sml, list, len, var, i) {
+        r = sml_variable_get_name(sml, var, tmp_name, sizeof(tmp_name));
+        if (r == 0 && strncmp(tmp_name, name, sizeof(tmp_name)) == 0)
+            return var;
+    }
+    return NULL;
+}
+#endif
+
+API_EXPORT bool
+sml_load_debug_data_log_file(struct sml_object *sml, const char *str)
+{
+#ifdef Debug
+    ON_NULL_RETURN_VAL(sml, false);
+    ON_NULL_RETURN_VAL(str, false);
+    FILE *file;
+    char line[LINE_SIZE];
+    char name[SML_VARIABLE_NAME_MAX_LEN + 1];
+    int int_val, ret;
+    float float_val, float_val2;
+    struct sml_variable *var;
+
+    file = fopen(str, "r");
+    ON_NULL_RETURN_VAL(file, false);
+
+    while (fgets(line, LINE_SIZE, file)) {
+        ret = strncmp(line, "sml_process", 11);
+        if (ret == 0) {
+            sml_process(sml);
+            continue;
+        }
+        ret = strncmp(line, "sml_predict", 11);
+        if (ret == 0) {
+            sml_predict(sml);
+            continue;
+        }
+        ret = sscanf(line, "sml_set_learn_disabled %d\n", &int_val);
+        if (ret > 0) {
+            sml_set_learn_disabled(sml, !!int_val);
+            continue;
+        }
+        ret = sscanf(line, "sml_new_input %127s\n", name);
+        if (ret > 0) {
+            sml_new_input(sml, name);
+            continue;
+        }
+        ret = sscanf(line, "sml_new_output %127s\n", name);
+        if (ret > 0) {
+            sml_new_output(sml, name);
+            continue;
+        }
+        ret = sscanf(line, "sml_variable_set_value %127s %f\n", name,
+            &float_val);
+        if (ret > 1) {
+            var = variable_find_by_name(sml, name);
+            if (var)
+                sml_variable_set_value(sml, var, float_val);
+            continue;
+        }
+        ret = sscanf(line, "sml_variable_set_enabled %127s %d\n", name,
+            &int_val);
+        if (ret > 1) {
+            var = variable_find_by_name(sml, name);
+            if (var)
+                sml_variable_set_enabled(sml, var, !!int_val);
+            continue;
+        }
+        ret = sscanf(line, "sml_remove_variable %127s\n", name);
+        if (ret > 0) {
+            var = variable_find_by_name(sml, name);
+            if (var)
+                sml_remove_variable(sml, var);
+            continue;
+        }
+        ret = sscanf(line, "sml_variable_set_range %127s %f %f\n", name,
+            &float_val, &float_val2);
+        if (ret > 2) {
+            var = variable_find_by_name(sml, name);
+            if (var)
+                sml_variable_set_range(sml, var, float_val, float_val2);
+            continue;
+        }
+    }
+
+
+    return true;
+#else
+    return false;
+#endif
+}
+
+API_EXPORT bool
 sml_set_learn_disabled(struct sml_object *sml, bool disable)
 {
     ON_NULL_RETURN_VAL(sml, false);
     struct sml_engine *engine = (struct sml_engine *)sml;
     engine->learn_disabled = disable;
+    SML_LOG_DEBUG_DATA(engine, "sml_set_learn_disabled %d\n", !!disable);
     return true;
 }
 
@@ -165,6 +369,7 @@ API_EXPORT int
 sml_process(struct sml_object *sml)
 {
     struct sml_engine *engine = (struct sml_engine *)sml;
+    int r;
 
     ON_NULL_RETURN_VAL(sml, -EINVAL);
     if (!engine->process) {
@@ -172,7 +377,9 @@ sml_process(struct sml_object *sml)
             "sml_process is mandatory for engines.");
         return -EINVAL;
     }
-    return engine->process(engine);
+    r = engine->process(engine);
+    SML_LOG_DEBUG_DATA(engine, "sml_process\n");
+    return r;
 }
 
 API_EXPORT bool
@@ -186,6 +393,7 @@ sml_predict(struct sml_object *sml)
             "sml_predict is mandatory for engines.");
         return false;
     }
+    SML_LOG_DEBUG_DATA(engine, "sml_predict\n");
     return engine->predict(engine);
 }
 
@@ -269,6 +477,7 @@ sml_new_input(struct sml_object *sml, const char *name)
         return NULL;
     }
 
+    SML_LOG_DEBUG_DATA(engine, "sml_new_input %s\n", name);
     return engine->new_input(engine, name);
 }
 
@@ -294,6 +503,7 @@ sml_new_output(struct sml_object *sml, const char *name)
         return NULL;
     }
 
+    SML_LOG_DEBUG_DATA(engine, "sml_new_output %s\n", name);
     return engine->new_output(engine, name);
 }
 
@@ -340,6 +550,9 @@ sml_variable_set_value(struct sml_object *sml,
             "sml_variable_set_value is mandatory for engines.");
         return false;
     }
+
+    SML_LOG_DEBUG_DATA_VAR(engine, "sml_variable_set_value", "%f\n",
+        sml_variable, value);
     return engine->set_value(sml_variable, value);
 }
 
@@ -393,6 +606,9 @@ sml_variable_set_enabled(struct sml_object *sml,
             "sml_variable_set_enabled is mandatory for engines.");
         return -EINVAL;
     }
+
+    SML_LOG_DEBUG_DATA_VAR(engine, "sml_variable_set_enabled", "%d\n",
+        sml_variable, !!enabled);
     return engine->variable_set_enabled(engine,
         sml_variable, enabled);
 }
@@ -425,6 +641,7 @@ sml_remove_variable(struct sml_object *sml, struct sml_variable *sml_variable)
             "sml_remove_variable is mandatory for engines.");
         return false;
     }
+    SML_LOG_DEBUG_DATA_VAR(engine, "sml_remove_variable", "", sml_variable);
     return engine->remove_variable(engine, sml_variable);
 }
 
@@ -499,6 +716,9 @@ sml_variable_set_range(struct sml_object *sml,
     if (isnan(max) && !sml_variable_get_range(sml, sml_variable, NULL, &max))
         return false;
 
+    SML_LOG_DEBUG_DATA_VAR(engine, "sml_variable_set_range", "%f %f\n",
+        sml_variable, min, max);
+
     if (max < min) {
         sml_warning("Max value (%f) is lower than min value (%f). Inverting.",
             max, min);
@@ -557,6 +777,11 @@ sml_call_read_state_cb(struct sml_engine *engine)
         engine->read_state_cb_data))
         return -EAGAIN;
 
+    SML_LOG_DEBUG_DATA(engine, "sml_call_read_state_cb\n");
+    SML_LOG_DEBUG_DATA_LIST(engine, "sml_call_read_state_cb input",
+        sml_get_input_list((struct sml_object *)engine));
+    SML_LOG_DEBUG_DATA_LIST(engine, "sml_call_read_state_cb output",
+        sml_get_output_list((struct sml_object *)engine));
     return 0;
 }
 
@@ -569,4 +794,9 @@ sml_call_output_state_changed_cb(struct sml_engine *engine,
 
     engine->output_state_changed_cb((struct sml_object *)engine, changed,
         engine->output_state_changed_cb_data);
+
+    SML_LOG_DEBUG_DATA(engine, "sml_call_output_state_changed_cb\n");
+    if (changed)
+        SML_LOG_DEBUG_DATA_LIST(engine,
+            "sml_call_output_state_changed_cb changed", changed);
 }

--- a/sml/common/src/sml_engine.c
+++ b/sml/common/src/sml_engine.c
@@ -544,3 +544,29 @@ sml_set_max_memory_for_observations(struct sml_object *sml,
     engine->obs_max_size = obs_max_size;
     return true;
 }
+
+int
+sml_call_read_state_cb(struct sml_engine *engine)
+{
+    if (!engine->read_state_cb) {
+        sml_critical("It's required to set a read_state_cb to read");
+        return -EINVAL;
+    }
+
+    if (!engine->read_state_cb((struct sml_object *)engine,
+        engine->read_state_cb_data))
+        return -EAGAIN;
+
+    return 0;
+}
+
+void
+sml_call_output_state_changed_cb(struct sml_engine *engine,
+    struct sml_variables_list *changed)
+{
+    if (!engine->output_state_changed_cb)
+        return;
+
+    engine->output_state_changed_cb((struct sml_object *)engine, changed,
+        engine->output_state_changed_cb_data);
+}

--- a/sml/common/src/sml_util.c
+++ b/sml/common/src/sml_util.c
@@ -53,6 +53,7 @@ bool
 file_exists(const char *path)
 {
     struct stat stat_result;
+
     if (!stat(path, &stat_result))
         return true;
     return false;

--- a/sml/include/sml.h
+++ b/sml/include/sml.h
@@ -395,6 +395,44 @@ bool sml_load(struct sml_object *sml, const char *path);
 void sml_print_debug(struct sml_object *sml, bool full);
 
 /**
+ * @brief Set the file to be used to debug data changes in this engine
+ *
+ * This file will be used to log all calls to methods that changes the current
+ * state of the sml engine data. This information may be used to reproduce the
+ * execution of sml for debug purposes. Methods that configure the sml are not
+ * logged.
+ *
+ * To use this feature, sml must be compiled with build type set to Debug.
+ *
+ * @param sml The ::sml_object object.
+ * @param str A string with full path of file to be used to write debug data.
+ * Use @c NULL or an empty string to disable data debug.
+ * @return @ true if debug file was updated successfully. @c false if operation
+ * failed or if sml was not compiled using Debug build type.
+ *
+ * @see ::sml_load_debug_data_log_file
+ */
+bool sml_set_debug_data_log_file(struct sml_object *sml, const char *str);
+
+/**
+ * @brief Load to current engine the debug data logged to a file
+ *
+ * Load all data logged in file set by ::sml_set_debug_data_log_file to current
+ * engine. Used for debug purposes.
+ *
+ * To use this feature, sml must be compiled with build type set to Debug.
+ *
+ * @param sml The ::sml_object object.
+ * @param str A string with full path of file to be used to load debug data.
+ * @return @ true if loading debug was successful. @c false if operation
+ * failed or if sml was not compiled using Debug build type.
+ *
+ * @see ::sml_set_debug_data_log_file
+ *
+ */
+bool sml_load_debug_data_log_file(struct sml_object *sml, const char *str);
+
+/**
  * @brief Set maximum memory that can be used to store observation history data.
  *
  * @remark max_size = 0 means infinite (it is also the default).
@@ -611,6 +649,11 @@ bool sml_variable_set_range(struct sml_object *sml, struct sml_variable *sml_var
  * @return @c false on failure.
  */
 bool sml_variable_get_range(struct sml_object *sml, struct sml_variable *sml_variable, float *min, float *max);
+
+#define SML_VARIABLES_LIST_FOREACH(sml, list, len, var, i)              \
+    for (i = 0, len = sml_variables_list_get_length(sml, list);         \
+        i < len && ((var = sml_variables_list_index(sml, list, i)));   \
+        i++)
 
 /**
  * @}


### PR DESCRIPTION
Add a method to save to a file all calls to functions that change
the state of the current engine and a method to load this file
and reproduce the saved changes.

This is used to reproduce a sml execution for debug purposes. All data
saved to inputs and outputs, predicted values and variables
adds/removals/disabled are saved.

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
