### PR TITLE
Create infra to save and load debug data V2

### DIFF
--- a/sml/common/include/sml_engine.h
+++ b/sml/common/include/sml_engine.h
@@ -65,6 +65,9 @@ typedef bool (*sml_engine_variable_set_range)(struct sml_engine *engine, struct 
 typedef bool (*sml_engine_variable_get_range)(struct sml_variable *sml_variable, float *min, float *max);
 typedef void (*sml_engine_print_debug)(struct sml_engine *engine, bool full);
 
+int sml_call_read_state_cb(struct sml_engine *engine);
+void sml_call_output_state_changed_cb(struct sml_engine *engine, struct sml_variables_list *changed);
+
 struct sml_engine {
     /* General API */
     sml_engine_load_file load_file;

--- a/sml/common/include/sml_engine.h
+++ b/sml/common/include/sml_engine.h
@@ -36,6 +36,8 @@
 #include <sml_ann.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <config.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,6 +99,9 @@ struct sml_engine {
 
     /* Debug API */
     sml_engine_print_debug print_debug;
+#ifdef Debug
+    FILE *debug_file;
+#endif
 
     uint32_t magic_number;
     sml_read_state_cb read_state_cb;

--- a/sml/common/src/sml_engine.c
+++ b/sml/common/src/sml_engine.c
@@ -544,3 +544,31 @@ sml_set_max_memory_for_observations(struct sml_object *sml,
     engine->obs_max_size = obs_max_size;
     return true;
 }
+
+int
+sml_call_read_state_cb(struct sml_engine *engine)
+{
+    if (!engine->read_state_cb) {
+        sml_critical("It's required to set a read_state_cb to read");
+        return -EINVAL;
+    }
+
+    if (!engine->read_state_cb((struct sml_object *)engine,
+        engine->read_state_cb_data))
+        return -EAGAIN;
+
+    return 0;
+}
+
+void
+sml_call_output_state_changed_cb(struct sml_engine *engine,
+    struct sml_variables_list *changed)
+{
+    if (!engine->output_state_changed_cb) {
+        sml_warning("output_state_changed called, but there is no callback registered.");
+        return;
+    }
+
+    engine->output_state_changed_cb((struct sml_object *)engine, changed,
+        engine->output_state_changed_cb_data);
+}

--- a/sml/common/src/sml_util.c
+++ b/sml/common/src/sml_util.c
@@ -53,6 +53,7 @@ bool
 file_exists(const char *path)
 {
     struct stat stat_result;
+
     if (!stat(path, &stat_result))
         return true;
     return false;

--- a/sml/include/sml.h
+++ b/sml/include/sml.h
@@ -395,6 +395,44 @@ bool sml_load(struct sml_object *sml, const char *path);
 void sml_print_debug(struct sml_object *sml, bool full);
 
 /**
+ * @brief Set the file to be used to debug data changes in this engine
+ *
+ * This file will be used to log all calls to methods that changes the current
+ * state of the sml engine data. This information may be used to reproduce the
+ * execution of sml for debug purposes. Methods that configure the sml are not
+ * logged.
+ *
+ * To use this feature, sml must be compiled with build type set to Debug.
+ *
+ * @param sml The ::sml_object object.
+ * @param str A string with full path of file to be used to write debug data.
+ * Use @c NULL or an empty string to disable data debug.
+ * @return @ true if debug file was updated successfully. @c false if operation
+ * failed or if sml was not compiled using Debug build type.
+ *
+ * @see ::sml_load_debug_log_file
+ */
+bool sml_set_debug_log_file(struct sml_object *sml, const char *str);
+
+/**
+ * @brief Load to current engine the debug data logged to a file
+ *
+ * Load all data logged in file set by ::sml_set_debug_log_file to current
+ * engine. Used for debug purposes.
+ *
+ * To use this feature, sml must be compiled with build type set to Debug.
+ *
+ * @param sml The ::sml_object object.
+ * @param str A string with full path of file to be used to load debug data.
+ * @return @ true if loading debug was successful. @c false if operation
+ * failed or if sml was not compiled using Debug build type.
+ *
+ * @see ::sml_set_debug_log_file
+ *
+ */
+bool sml_load_debug_log_file(struct sml_object *sml, const char *str);
+
+/**
  * @brief Set maximum memory that can be used to store observation history data.
  *
  * @remark max_size = 0 means infinite (it is also the default).
@@ -611,6 +649,11 @@ bool sml_variable_set_range(struct sml_object *sml, struct sml_variable *sml_var
  * @return @c false on failure.
  */
 bool sml_variable_get_range(struct sml_object *sml, struct sml_variable *sml_variable, float *min, float *max);
+
+#define SML_VARIABLES_LIST_FOREACH(sml, list, len, var, i)              \
+    for (i = 0, len = sml_variables_list_get_length(sml, list);         \
+        i < len && ((var = sml_variables_list_index(sml, list, i)));   \
+        i++)
 
 /**
  * @}


### PR DESCRIPTION
Changes from v1:
- logging when output_state_changed_cb is called
- Flush file after every write
- Use variable_find_by_name implemented in each engine instead of reimplementing it.
- Close the file at the end of sml_load_debug_data_log_file
- rename sml_load_debug_data_log_file to sml_load_debug_log_file and sml_set_debug_data_log_file to sml_set_debug_log_file
- Using this log implementation in soletta nodes, instead of the debug implemented in the node
- Setting read_state_cb and output_changed_cb to dummy implementations before loading debug data from log file. Setting them back at the end.

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
