### PR TITLE
soletta_module: fix race condition in debug_file process functions

### DIFF
--- a/soletta_module/machine_learning/machine_learning.json
+++ b/soletta_module/machine_learning/machine_learning.json
@@ -146,6 +146,14 @@
             "process": "save_process"
         },
         "name":"SAVE"
+       },
+       {
+        "data_type": "string",
+        "description": "File to log sml read data and predicted outputs.",
+        "methods": {
+         "process": "debug_file_process"
+        },
+        "name": "DEBUG_FILE"
        }
       ],
       "methods": {
@@ -254,6 +262,14 @@
             "process": "save_process"
         },
         "name":"SAVE"
+       },
+       {
+        "data_type": "string",
+        "description": "File to log sml read data and predicted outputs.",
+        "methods": {
+         "process": "debug_file_process"
+        },
+        "name": "DEBUG_FILE"
        }
       ],
       "methods": {


### PR DESCRIPTION
We need to call sml functions in worker threads and
sml_set_debug_log_file was being called in main thread. Fixing this
issue.

This patch also adds the debug_file feature to regular sml nodes.

Signed-off-by: Otavio Pontes otavio.pontes@intel.com
